### PR TITLE
Add companions packages of git for linux installs

### DIFF
--- a/book/01-introduction/sections/installing.asc
+++ b/book/01-introduction/sections/installing.asc
@@ -14,19 +14,19 @@ Since Git is quite excellent at preserving backwards compatibility, any version 
 ==== Installing on Linux
 
 (((Linux, installing)))
-If you want to install Git on Linux via a binary installer, you can generally do so through the basic package-management tool that comes with your distribution.
+If you want to install the basic Git tools on Linux via a binary installer, you can generally do so through the basic package-management tool that comes with your distribution.
 If you're on Fedora for example, you can use yum:
 
 [source,console]
 ----
-$ sudo yum install git
+$ sudo yum install git-all
 ----
 
 If you're on a Debian-based distribution like Ubuntu, try apt-get:
 
 [source,console]
 ----
-$ sudo apt-get install git
+$ sudo apt-get install git-all
 ----
 
 For more options, there are instructions for installing on several different Unix flavors on the Git website, at http://git-scm.com/download/linux[].


### PR DESCRIPTION
On most linux distribution, the git package only provide the bare
command line git command. To have at least the same tools as for the
other OS, some additional packages are needed.progit2
